### PR TITLE
Bulk index batched query

### DIFF
--- a/djes/__init__.py
+++ b/djes/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.93"
+__version__ = "0.1.94"
 
 default_app_config = "djes.apps.DJESConfig"

--- a/djes/management/commands/bulk_index.py
+++ b/djes/management/commands/bulk_index.py
@@ -4,6 +4,7 @@ from elasticsearch.helpers import streaming_bulk
 
 from djes.apps import indexable_registry
 from djes.conf import settings
+from djes.util import batched_queryset
 
 
 def model_iterator(model, index=None, out=None):
@@ -14,7 +15,7 @@ def model_iterator(model, index=None, out=None):
     total = model.search_objects.count()
     if out:
         out.write("Indexing {} {} objects".format(total, model.__name__))
-    for obj in model.search_objects.iterator():
+    for obj in batched_queryset(model.objects.all()):
         if obj.__class__ != model:
             # TODO: Come up with a better method to avoid redundant indexing
             continue

--- a/djes/util.py
+++ b/djes/util.py
@@ -1,0 +1,29 @@
+import gc
+
+
+def batched_queryset(queryset, chunksize=1000):
+    '''''
+    Iterate over a Django Queryset ordered by the primary key
+
+    This method loads a maximum of chunksize (default: 1000) rows in it's
+    memory at the same time while django normally would load all rows in it's
+    memory. Using the iterator() method only causes it to not preload all the
+    classes.
+
+    Note that the implementation of the iterator does not support ordered query sets.
+
+    Source: https://djangosnippets.org/snippets/1949/
+    '''
+    try:
+        last_pk = queryset.order_by('-pk')[0].pk
+    except IndexError:
+        # Support empty querysets
+        return
+
+    queryset = queryset.order_by('pk')
+    pk = 0
+    while pk < last_pk:
+        for row in queryset.filter(pk__gt=pk)[:chunksize]:
+            pk = row.pk
+            yield row
+        gc.collect()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,8 +31,37 @@ def test_count_batch_queries(es_client):
                                             (5, 3),
                                             (3, 5)]:
             reset_queries()
-            chunks = list(batched_queryset(SimpleObject.objects.all(), chunksize=chunksize))
-            assert objects == chunks
+            results = list(batched_queryset(SimpleObject.objects.all(), chunksize=chunksize))
+            assert objects == results
             assert len(connection.queries) == expected_queries
     finally:
         settings.DEBUG = False
+
+
+@pytest.mark.django_db
+def test_delete_during_query(es_client):
+    objects = mommy.make(SimpleObject, _quantity=10)
+    qs = batched_queryset(SimpleObject.objects.all(), chunksize=3)
+    results = [next(qs) for _ in range(3)]
+    # Delete during batched fetch
+    objects[3].delete()  # Not yet fetched
+    # Finish batched fetch
+    results.extend(list(qs))
+    # Querys
+    assert results == (objects[:3] + objects[4:])
+
+
+@pytest.mark.django_db
+def test_create_during_query(es_client):
+    objects = mommy.make(SimpleObject, _quantity=10)
+    qs = batched_queryset(SimpleObject.objects.all(), chunksize=3)
+    results = [next(qs) for _ in range(3)]
+    # Create more objects during batched fetch
+    new_objects = mommy.make(SimpleObject, _quantity=10)
+    # Finish batched fetch
+    results.extend(list(qs))
+
+    # Final chunk (based on initial object count 10) would normally be size 1. Number of chunks
+    # fetched is based on initial size, but last chunk fetched will grab enough new objects to fill
+    # chunk (size 3).
+    assert results == (objects + new_objects[:2])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,38 @@
+from django.db import connection, reset_queries
+from django.conf import settings
+import pytest
+from model_mommy import mommy
+
+from djes.util import batched_queryset
+from example.app.models import SimpleObject
+
+
+@pytest.mark.django_db
+def test_empty_queryset(es_client):
+    assert list(batched_queryset(SimpleObject.objects.all())) == []
+
+
+@pytest.mark.django_db
+def test_various_chunk_sizes(es_client):
+    objects = mommy.make(SimpleObject, _quantity=10)
+    for size in range(1, 12):
+        assert objects == list(batched_queryset(SimpleObject.objects.all(), chunksize=size))
+
+
+@pytest.mark.django_db
+def test_count_batch_queries(es_client):
+    objects = mommy.make(SimpleObject, _quantity=10)
+
+    try:
+        settings.DEBUG = True  # Must be TRUE to track connection queries
+
+        # 1 query to get initial primary key, plus 1 per batch
+        for chunksize, expected_queries in [(10, 2),
+                                            (5, 3),
+                                            (3, 5)]:
+            reset_queries()
+            chunks = list(batched_queryset(SimpleObject.objects.all(), chunksize=chunksize))
+            assert objects == chunks
+            assert len(connection.queries) == expected_queries
+    finally:
+        settings.DEBUG = False


### PR DESCRIPTION
@benghaziboy @collin 
Workaround for Django queryset iterator pulling everything into memory, causing resource issues on large data sets.

Still need to add a few more tests