### PR TITLE
Fix sync es

### DIFF
--- a/djes/__init__.py
+++ b/djes/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.96"
+__version__ = "0.1.97"
 
 default_app_config = "djes.apps.DJESConfig"

--- a/djes/management/commands/bulk_index.py
+++ b/djes/management/commands/bulk_index.py
@@ -32,18 +32,20 @@ def model_iterator(model, index=None, out=None):
 
 
 def bulk_index(es, index=None, version=1, out=None):
-    if index not in indexable_registry.indexes:
+    index_base = index.rpartition('_')[0]
+    # TODO: we need to reassess how we reference aliases and indices.
+    if index_base not in indexable_registry.indexes:
         # Looks like someone is requesting the indexing of something we don't have models for
         return
 
-    vindex = "{0}_{1:0>4}".format(index, version)
+    vindex = "{0}_{1:0>4}".format(index_base, version)
 
     es.indices.put_settings(
         index=vindex,
         body={"index": {"refresh_interval": "-1"}}
     )
 
-    for model in indexable_registry.indexes[index]:
+    for model in indexable_registry.indexes[index_base]:
 
         identifier = "{}.{}".format(model._meta.app_label, model._meta.object_name)
         if identifier in settings.DJES_EXCLUDED_MODELS:

--- a/djes/models.py
+++ b/djes/models.py
@@ -1,7 +1,6 @@
 from django.db import models
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl.connections import connections
-from elasticsearch_dsl.field import InnerObject
 
 from .apps import indexable_registry
 from .factory import shallow_class_factory
@@ -213,4 +212,4 @@ class Indexable(models.Model):
         for subclass in cls.__subclasses__():
             names += subclass.get_doc_types()
             # names.append(subclass.search_objects.mapping.doc_type)
-        return names  
+        return names

--- a/tests/test_bulk_index.py
+++ b/tests/test_bulk_index.py
@@ -1,11 +1,12 @@
 from django.core import management
-import pytest
-from model_mommy import mommy
-import time
 
-from example.app.models import SimpleObject
+import pytest
+import time
+from model_mommy import mommy
 
 from djes.management.commands.bulk_index import model_iterator
+
+from example.app.models import SimpleObject
 
 
 @pytest.mark.django_db
@@ -28,3 +29,16 @@ def test_bulk_index(es_client):
         doc_type=SimpleObject.search_objects.mapping.doc_type
     )
     assert response["hits"]["total"] == 120
+
+
+@pytest.mark.django_db
+def test_bulk_index_called_in_sync_es(es_client):
+    mommy.make(SimpleObject, _quantity=120)
+
+    # TODO: weird race condition with fixtures recreating the indices.
+    es_client.indices.delete("djes-example*", ignore=[404])
+    assert es_client.indices.exists_alias(name='djes-example') is False
+    assert es_client.indices.exists('djes-example_0001') is False
+    management.call_command("sync_es")
+    assert es_client.indices.exists_alias(name='djes-example') is True
+    assert es_client.indices.exists('djes-example_0001') is True


### PR DESCRIPTION
@mparent61 @MichaelButkovic 

The distinction between an index & alias needs to be made more explicitly throughout djes, so for the time being I am going to allow `bulk_index` to tolerate either a versioned index name or alias and index accordingly